### PR TITLE
Refactor deploy_wildfly to use wildfly_systemd role provided by middleware_automation.jcliff collection

### DIFF
--- a/middleware_demo/deploy_wildfly.yml
+++ b/middleware_demo/deploy_wildfly.yml
@@ -13,14 +13,47 @@
     java_opts: "-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"
     java_path: /usr/bin/java
     jboss_home_path: /opt/jboss/wildfly
+    wildfly_home: "{{ jboss_home_path }}"
+    instance_name: jboss-wildfly
+    wildfly_user: 'jboss'
+    wildfly_group: 'jboss'
+    wildfly_uid: 1001
+    wildfly_gid: 1001
     wildfly_version: 24.0.0.Final
     wildfly_sha1: 391346c9ed2772647ff07aeae39deb838ee11dcf
+    wildfly_config_base: standalone.xml
   environment:
     JAVA_HOME: "{{ java_home_path }}"
     WILDFLY_VERSION: "{{ wildfly_version }}"
     WILDFLY_SHA1: "{{ wildfly_sha1 }}"
     JBOSS_HOME: "{{ jboss_home_path }}"
     LAUNCH_JBOSS_IN_BACKGROUND: true
-
+  collections:
+    - middleware_automation.jcliff
   roles:
+    - prereqs
     - deploy_wildfly
+    - wildfly_systemd
+  post_tasks:
+
+    - name: "Check that service {{ instance_name }} is running"
+      service:
+        name: "{{ instance_name }}"
+        state: started
+
+    - name: "Check that port is open"
+      wait_for:
+        port: 8080
+        host: "{{ item }}"
+      loop:
+        - localhost
+
+    - name: "Check that server is responsive"
+      get_url:
+        url: "http://localhost:8080/"
+        dest: /tmp/res.txt
+
+    - file:
+        state: absent
+        path: /tmp/res.txt
+      changed_when: false

--- a/middleware_demo/roles/deploy_wildfly/tasks/main.yml
+++ b/middleware_demo/roles/deploy_wildfly/tasks/main.yml
@@ -1,60 +1,26 @@
 ---
-- name: Add EPEL repository
-  yum_repository:
-    name: epel
-    description: EPEL YUM repo
-    file: epel_repos
-    baseurl: "{{ epel_baseurl }}"
-    gpgcheck: yes
+- assert:
+    that:
+      - wildfly_user is defined
+      - wildfly_group is defined
+      - wildfly_uid is defined
+      - wildfly_gid is defined
+    quiet: true
 
-- name: Add GPG Key
-  rpm_key:
-    state: present
-    key: "{{ epel_rpm_key }}"
-
-- name: Upgrade all packages
-  yum:
-    name: '*'
-    state: latest
-
-- name: Install the required packages
-  yum:
-    name: "{{ item }}"
-    state: present
-  loop:
-    - xmlstarlet
-    - augeas
-    - bsdtar
-    - unzip
-    - java-11-openjdk-devel
-
-- name: Create jboss group
+- name: "Create {{ wildfly_group }} group"
   group:
-    name: jboss
+    name: "{{ wildfly_group }}"
     state: present
-    gid: 1001
+    gid: "{{ wildfly_gid }}"
 
-- name: Create {{ jboss_home_directory }} directory
-  file:
-    path: "{{ jboss_home_directory }}"
-    state: directory
-    mode: '0755'
-
-- name: Create jboss user
+- name: "Create {{ wildfly_user }} user"
   user:
-    name: jboss
+    name: "{{ wildfly_user }}"
     comment: JBoss User
-    uid: 1001
-    group: jboss
+    uid: "{{ wildfly_uid }}"
+    group: "{{ wildfly_group }}"
     home: "{{ jboss_home_directory }}"
-
-- name: Update ownership of {{ jboss_home_directory }}
-  file:
-    path: "{{ jboss_home_directory }}"
-    state: directory
-    recurse: yes
-    owner: jboss
-    group: jboss
+    state: present
 
 # Add the WildFly distribution to /opt, and make wildfly the owner of the extracted tar content
 - name: Download and Add WildFly distribution
@@ -74,20 +40,3 @@
         && chmod -R g+rw ${JBOSS_HOME}
       args:
         chdir: "{{ jboss_home_directory }}"
-
-- name: Create jboss-wildfly.service systemd unit file
-  template:
-    src: templates/jboss-wildfly.service.j2
-    dest: /etc/systemd/system/jboss-wildfly.service
-    mode: 0755
-
-- name: Start WildFly and issue daemon-reload to pick up config changes
-  systemd:
-    state: started
-    daemon_reload: yes
-    name: jboss-wildfly
-
-- name: Enable jboss-wildfly service
-  service:
-    name: jboss-wildfly
-    enabled: yes

--- a/middleware_demo/roles/prereqs/tasks/main.yml
+++ b/middleware_demo/roles/prereqs/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Add EPEL repository
+  yum_repository:
+    name: epel
+    description: EPEL YUM repo
+    file: epel_repos
+    baseurl: "{{ epel_baseurl }}"
+    gpgcheck: yes
+
+- name: Add GPG Key
+  rpm_key:
+    state: present
+    key: "{{ epel_rpm_key }}"
+
+- name: Upgrade all packages
+  yum:
+    name: '*'
+    state: latest
+
+- name: Install the required packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - xmlstarlet
+    - augeas
+    - bsdtar
+    - unzip
+    - java-11-openjdk-devel


### PR DESCRIPTION
This refactoring removes a few operations that are already provided by the wildfly_systemd role coming with the middleware_automation.jcliff collection. I also removed the yum update part to place it into a separate role. 

I've tested this changes locally, inside a Podman container, so you may need to tweak a bit for it to work on EC2.


Note: for this change to work, you need to install the collection first:
```
$ ansible-galaxy collection install middleware_automation.jcliff collection
``` 